### PR TITLE
XMDEV-480: Fixes bug with changelog appending

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       api_changes: ${{ steps.filter.outputs.api }}
-      frontend_changes: ${{ steps.filter.outputs.frontend }}
+      metrics_changes: ${{ steps.filter.outputs.metrics }}
       dependency_changes: ${{ steps.filter.outputs.dependencies }}
       has_labels: ${{ steps.determine-labels.outputs.has_labels }}
       labels: ${{ steps.determine-labels.outputs.labels }}
@@ -143,7 +143,7 @@ jobs:
           CHANGELOG=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"- %s (%h) by %an")
 
           if [ -n "$CHANGELOG" ]; then
-            echo "## Changelog" >> CHANGELOG.md
+            echo "## Changelog" > CHANGELOG.md
             echo "### From $LATEST_TAG to HEAD" >> CHANGELOG.md
             echo "" >> CHANGELOG.md
             echo "$CHANGELOG" >> CHANGELOG.md


### PR DESCRIPTION
## Description
There was a bug that was causing the generation of the changelog to be appended to the existing notes instead of overwriting it. This PR fixes that bug

## Approach Taken
Pesky bash commands! `>` vs `>>` was the culprit. I corrected for the extra character.

## What Could Go Wrong?
This is a bug fix. Things have already gone wrong.

## Remediation Strategy
NA
