### PR TITLE
XMDEV-505: Adds observer configuration per metric

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2086,6 +2086,30 @@ files = [
 wcwidth = "*"
 
 [[package]]
+name = "psutil"
+version = "7.0.0"
+description = "Cross-platform lib for process and system monitoring in Python.  NOTE: the syntax of this script MUST be kept compatible with Python 2.7."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25"},
+    {file = "psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993"},
+    {file = "psutil-7.0.0-cp36-cp36m-win32.whl", hash = "sha256:84df4eb63e16849689f76b1ffcb36db7b8de703d1bc1fe41773db487621b6c17"},
+    {file = "psutil-7.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:1e744154a6580bc968a0195fd25e80432d3afec619daf145b9e5ba16cc1d688e"},
+    {file = "psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99"},
+    {file = "psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553"},
+    {file = "psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black (==24.10.0)", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest", "pytest-cov", "pytest-xdist", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
+test = ["pytest", "pytest-xdist", "setuptools"]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 description = "Data validation using Python type hints"
@@ -3443,4 +3467,4 @@ test = ["pytest", "pytest-asyncio"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "9c4a637e50a30ecfa375bf5f6199c9a286d3e9adeaa953e42bcef061df498012"
+content-hash = "a9446e6f709b1a0855fda9869543cfbc80f1b80131ee3e4229793d0eb25ead1e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pytest-asyncio = { version = "^1.1.0", optional = true }
 black = { version = "^25.1.0", optional = true }
 pyright = { version = "^1.1.403", optional = true }
 pylint = { version = "^3.3.8", optional = true }
+psutil = "^7.0.0"
 
 [tool.poetry.extras]
 # Individual metric extras
@@ -78,6 +79,9 @@ disable = [
   "W0212", # protected-access
   "W0718", # broad-exception-caught
 ]
+
+[tool.pylint.design]
+max-attributes = 10
 
 max-line-length = 100
 jobs = 4

--- a/src/core/metrics/observers/device_metrics_observer.py
+++ b/src/core/metrics/observers/device_metrics_observer.py
@@ -1,0 +1,300 @@
+"""Device metrics observer for tracking system resource usage during metric computation."""
+
+import time
+import threading
+import logging
+from typing import List, Dict, Any, Optional
+import psutil
+
+from src.models.schemas import MetricResult
+from src.core.metrics.metric_observer import MetricObserver
+
+logger = logging.getLogger(__name__)
+
+
+class DeviceMetricsObserver(MetricObserver):
+    """Observer that tracks and reports device metrics during metric computation."""
+
+    def __init__(self):
+        """
+        Initialize the device metrics observer.
+        """
+
+        # Tracking state
+        self._monitoring = False
+        self._monitor_thread: Optional[threading.Thread] = None
+        self._current_metric = ""
+        self._total_pairs = 0
+        self._processed_pairs = 0
+
+        # Metrics storage
+        self._baseline_metrics: Dict[str, Any] = {}
+        self._peak_metrics: Dict[str, Any] = {}
+        self._final_metrics: Dict[str, Any] = {}
+        self._snapshots: List[Dict[str, Any]] = []
+
+    def _get_current_metrics(self) -> Dict[str, Any]:
+        """Get current system metrics snapshot."""
+        process = psutil.Process()
+
+        # Get system-wide metrics
+        cpu_percent = psutil.cpu_percent(interval=0.1)
+        memory = psutil.virtual_memory()
+        disk_io = psutil.disk_io_counters()
+
+        # Get process-specific metrics
+        with process.oneshot():
+            process_memory = process.memory_info()
+            process_cpu = process.cpu_percent()
+
+        metrics = {
+            "timestamp": time.time(),
+            # System-wide metrics
+            "system_cpu_percent": cpu_percent,
+            "system_memory_used_gb": memory.used / (1024**3),
+            "system_memory_total_gb": memory.total / (1024**3),
+            "system_memory_percent": memory.percent,
+            "system_memory_available_gb": memory.available / (1024**3),
+            # Process-specific metrics
+            "process_cpu_percent": process_cpu,
+            "process_memory_rss_gb": process_memory.rss
+            / (1024**3),  # Resident Set Size
+            "process_memory_vms_gb": process_memory.vms
+            / (1024**3),  # Virtual Memory Size
+            # I/O metrics (system-wide)
+            "disk_read_mb": disk_io.read_bytes / (1024**2) if disk_io else 0,
+            "disk_write_mb": disk_io.write_bytes / (1024**2) if disk_io else 0,
+            # Progress tracking
+            "processed_pairs": self._processed_pairs,
+            "total_pairs": self._total_pairs,
+            "progress_percent": (
+                (self._processed_pairs / self._total_pairs * 100)
+                if self._total_pairs > 0
+                else 0
+            ),
+        }
+
+        return metrics
+
+    def _update_peak_metrics(self, current: Dict[str, Any]) -> None:
+        """Update peak metrics with current values where applicable."""
+        if not self._peak_metrics:
+            self._peak_metrics = current.copy()
+            return
+
+        # Update peaks for relevant metrics
+        peak_keys = [
+            "system_cpu_percent",
+            "system_memory_percent",
+            "system_memory_used_gb",
+            "process_cpu_percent",
+            "process_memory_rss_gb",
+            "process_memory_vms_gb",
+        ]
+
+        for key in peak_keys:
+            if key in current and current[key] > self._peak_metrics.get(key, 0):
+                self._peak_metrics[key] = current[key]
+
+    def _log_metrics_snapshot(
+        self, metrics: Dict[str, Any], snapshot_type: str
+    ) -> None:
+        """Log a formatted metrics snapshot."""
+        timestamp_str = time.strftime("%H:%M:%S", time.localtime(metrics["timestamp"]))
+
+        logger.info(
+            "[%s] Device Metrics Snapshot - %s - %s (Elapsed: %.1fs)",
+            snapshot_type,
+            self._current_metric,
+            timestamp_str,
+            metrics["elapsed_seconds"],
+        )
+        logger.info(
+            "  System: CPU %.1f%%, "
+            "RAM %.2fGB/"
+            "%.2fGB "
+            "(%.1f%%), "
+            "Available %.2fGB",
+            metrics["system_cpu_percent"],
+            metrics["system_memory_used_gb"],
+            metrics["system_memory_total_gb"],
+            metrics["system_memory_percent"],
+            metrics["system_memory_available_gb"],
+        )
+        logger.info(
+            "  Process: CPU %.1f%%, RSS %.2fGB, VMS %.2fGB",
+            metrics["process_cpu_percent"],
+            metrics["process_memory_rss_gb"],
+            metrics["process_memory_vms_gb"],
+        )
+        logger.info(
+            "  Progress: %d/%d pairs (%.1f%%)",
+            metrics["processed_pairs"],
+            metrics["total_pairs"],
+            metrics["progress_percent"],
+        )
+
+    def _continuous_monitor(self) -> None:
+        """Continuously monitor system metrics in a separate thread."""
+        logger.info(
+            "Started continuous monitoring for %s (interval: %ss)",
+            self._current_metric,
+            2.0,
+        )
+
+        while self._monitoring:
+            try:
+                current = self._get_current_metrics()
+                self._update_peak_metrics(current)
+                self._snapshots.append(current.copy())
+
+                self._log_metrics_snapshot(current, "CONTINUOUS")
+
+                time.sleep(2.0)
+
+            except Exception as e:
+                logger.error("Error during continuous monitoring: %s", e)
+                break
+
+    def _log_summary(self) -> None:
+        """Log summary of metrics for the completed metric computation."""
+        if not self._baseline_metrics or not self._final_metrics:
+            logger.warning(
+                "Cannot generate summary - missing baseline or final metrics"
+            )
+            return
+
+        duration = self._final_metrics["elapsed_seconds"]
+
+        logger.info("=" * 60)
+        logger.info("DEVICE METRICS SUMMARY: %s", self._current_metric)
+        logger.info("=" * 60)
+        logger.info("Duration: %.2f seconds", duration)
+        logger.info("Total snapshots captured: %d", len(self._snapshots))
+
+        # System metrics comparison
+        logger.info("SYSTEM METRICS (Baseline → Peak → Final)")
+        logger.info("-" * 40)
+
+        cpu_baseline = self._baseline_metrics.get("system_cpu_percent", 0)
+        cpu_peak = self._peak_metrics.get("system_cpu_percent", 0)
+        cpu_final = self._final_metrics.get("system_cpu_percent", 0)
+        logger.info("CPU: %.1f%% → %.1f%% → %.1f%%", cpu_baseline, cpu_peak, cpu_final)
+
+        mem_baseline = self._baseline_metrics.get("system_memory_used_gb", 0)
+        mem_peak = self._peak_metrics.get("system_memory_used_gb", 0)
+        mem_final = self._final_metrics.get("system_memory_used_gb", 0)
+        logger.info(
+            "System RAM: %.2fGB → %.2fGB → %.2fGB", mem_baseline, mem_peak, mem_final
+        )
+
+        # Process metrics comparison
+        logger.info("PROCESS METRICS (Baseline → Peak → Final)")
+        logger.info("-" * 40)
+
+        logger.info(
+            "Process CPU: %.1f%% → %.1f%% → %.1f%%",
+            self._baseline_metrics.get("process_cpu_percent", 0),
+            self._peak_metrics.get("process_cpu_percent", 0),
+            self._final_metrics.get("process_cpu_percent", 0),
+        )
+
+        proc_mem_baseline = self._baseline_metrics.get("process_memory_rss_gb", 0)
+        proc_mem_final = self._final_metrics.get("process_memory_rss_gb", 0)
+        proc_mem_change = proc_mem_final - proc_mem_baseline
+        logger.info(
+            "Process RSS: %.2fGB → %.2fGB → %.2fGB (%+.2fGB)",
+            proc_mem_baseline,
+            self._peak_metrics.get("process_memory_rss_gb", 0),
+            proc_mem_final,
+            proc_mem_change,
+        )
+
+        # Performance summary
+        avg_pairs_per_second = self._total_pairs / duration if duration > 0 else 0
+        logger.info("Processing rate: %.2f pairs/second", avg_pairs_per_second)
+
+        logger.info("=" * 60)
+
+    def on_metric_start(self, metric_name: str, total_pairs: int) -> None:
+        """Called when metric computation starts."""
+        self._current_metric = metric_name
+        self._total_pairs = total_pairs
+        self._processed_pairs = 0
+        self._snapshots.clear()
+
+        # Get baseline metrics
+        self._baseline_metrics = self._get_current_metrics()
+        self._peak_metrics = self._baseline_metrics.copy()
+
+        logger.info("🚀 Starting metric computation: %s", metric_name)
+        logger.info("📊 Total pairs to process: %d", total_pairs)
+
+        # Log baseline snapshot
+        self._log_metrics_snapshot(self._baseline_metrics, "START")
+
+        # Start continuous monitoring
+        self._monitoring = True
+        self._monitor_thread = threading.Thread(
+            target=self._continuous_monitor, daemon=True
+        )
+        self._monitor_thread.start()
+
+    def on_pair_processed(
+        self, metric_name: str, pair_index: int, result: MetricResult
+    ) -> None:
+        """Called when a text pair is processed."""
+        self._processed_pairs = pair_index + 1
+
+        # Log progress at certain intervals
+        if (
+            self._processed_pairs % 50 == 0
+            or self._processed_pairs == self._total_pairs
+        ):
+            progress_pct = (self._processed_pairs / self._total_pairs) * 100
+
+            logger.info(
+                "📈 Progress: %d/%d pairs (%.1f%%)",
+                self._processed_pairs,
+                self._total_pairs,
+                progress_pct,
+            )
+
+    def on_metric_complete(self, metric_name: str, results: List[MetricResult]) -> None:
+        """Called when metric computation completes."""
+        # Stop continuous monitoring
+        self._monitoring = False
+        if self._monitor_thread and self._monitor_thread.is_alive():
+            self._monitor_thread.join(timeout=2.0)
+
+        # Get final metrics snapshot
+        self._final_metrics = self._get_current_metrics()
+        self._update_peak_metrics(self._final_metrics)
+
+        logger.info("✅ Completed metric computation: %s", metric_name)
+        logger.info("📈 Processed %d results", len(results))
+
+        # Log final snapshot
+        self._log_metrics_snapshot(self._final_metrics, "END")
+
+        # Log comprehensive summary
+        self._log_summary()
+
+    def on_metric_error(self, metric_name: str, error: Exception) -> None:
+        """Called when metric computation fails."""
+        # Stop continuous monitoring
+        self._monitoring = False
+        if self._monitor_thread and self._monitor_thread.is_alive():
+            self._monitor_thread.join(timeout=2.0)
+
+        # Get final metrics even on error
+        self._final_metrics = self._get_current_metrics()
+
+        logger.error("❌ Error in metric computation: %s", metric_name)
+        logger.error("🚨 Error details: %s", str(error))
+
+        # Log final snapshot
+        self._log_metrics_snapshot(self._final_metrics, "ERROR")
+
+        # Log summary even on error
+        self._log_summary()

--- a/src/core/metrics/observers/progress_tracker_observer.py
+++ b/src/core/metrics/observers/progress_tracker_observer.py
@@ -1,0 +1,26 @@
+"""
+Simple progress tracker observer.
+Outputs print statements at various intervals
+"""
+
+from src.core.metrics.base import MetricObserver
+
+
+class ProgressTracker(MetricObserver):
+    """Progress Tracker observer"""
+
+    def on_metric_start(self, metric_name: str, total_pairs: int):
+        """Notify on metrics start"""
+        print(f"Starting {metric_name} for {total_pairs} pairs")
+
+    def on_pair_processed(self, metric_name: str, pair_index: int, result):
+        """Notify on pair processed"""
+        print(f"{metric_name}: processed pair {pair_index}")
+
+    def on_metric_complete(self, metric_name: str, results):
+        """Notify on metric complete"""
+        print(f"{metric_name}: completed with {len(results)} results")
+
+    def on_metric_error(self, metric_name: str, error):
+        """Notify on metric error"""
+        print(f"{metric_name}: error occurred: {error}")

--- a/src/core/metrics/registry.py
+++ b/src/core/metrics/registry.py
@@ -257,6 +257,15 @@ class MetricRegistry:
         self._discovered = False
         self.discover_metrics()
 
+    def are_metrics_discovered(self) -> bool:
+        """Public method letting users know
+        if metrics have been discovered yet
+
+        Returns:
+            bool: True if metrics have been discovered
+        """
+        return self._discovered
+
 
 # Global registry instance
 metric_registry = MetricRegistry()

--- a/tests/tasks/test_celery_app.py
+++ b/tests/tasks/test_celery_app.py
@@ -106,13 +106,13 @@ class TestComputeMetricsForRequest:
     ):
         """Test successful metrics computation for request."""
         # Setup mock registry
-        mock_registry.discover_metrics.return_value = None
+        mock_registry.are_metrics_discovered.return_value = True
         mock_registry.get_metrics.return_value = {"bert_score": mock_metric_instance}
 
         results = compute_metrics_for_request(sample_request_data)
 
         # Verify registry interactions
-        mock_registry.discover_metrics.assert_called_once()
+        mock_registry.are_metrics_discovered.assert_called_once()
         mock_registry.get_metrics.assert_called_once_with(["bert_score"])
 
         # Verify results structure
@@ -223,7 +223,7 @@ class TestComputeMetricsForRequest:
         self, mock_registry, sample_request_data: Dict[str, Any]
     ):
         """Test handling of metric registry discovery failure."""
-        mock_registry.discover_metrics.side_effect = Exception(
+        mock_registry.are_metrics_discovered.side_effect = Exception(
             "Registry discovery failed"
         )
 
@@ -850,7 +850,7 @@ class TestWebhookFunctionality:
         self, mock_registry, webhook_request_data
     ):
         """Test compute_metrics_task error handling with webhook notification."""
-        mock_registry.discover_metrics.side_effect = ValueError("Registry error")
+        mock_registry.are_metrics_discovered.side_effect = ValueError("Registry error")
 
         mock_task = Mock()
         mock_task.update_state = Mock()
@@ -875,7 +875,7 @@ class TestWebhookFunctionality:
         self, mock_registry, webhook_request_data
     ):
         """Test compute_metrics_task error handling with webhook exception."""
-        mock_registry.discover_metrics.side_effect = ValueError("Registry error")
+        mock_registry.are_metrics_discovered.side_effect = ValueError("Registry error")
 
         mock_task = Mock()
         mock_task.update_state = Mock()


### PR DESCRIPTION
## Description
We weren't configuring metric observers. This PR adds a dedicated folder and two examples, then updates the processing to configure observers per metric.

## Approach Taken
Adds a dedicated subroutine.

## What Could Go Wrong?
Nothing really. This solely adds some config changes to setting up observers per metric.

## Remediation Strategy
NA
