### PR TITLE
XMDEV-509: Update github labels so update text applies to enhancement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             LABELS+=("github_actions")
           fi
 
-          if git log --pretty=%B ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -Eiq 'Add|add|create|Create'; then
+          if git log --pretty=%B ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -Eiq 'Add|add|create|Create|Update|update'; then
             LABELS+=("enhancement")
           fi
 
@@ -84,7 +84,7 @@ jobs:
             LABELS+=("bug")
           fi
 
-          if git log --pretty=%B ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -Eiq 'refactor|Refactor|Update|update'; then
+          if git log --pretty=%B ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -Eiq 'refactor|Refactor'; then
             LABELS+=("refactor")
           fi
 


### PR DESCRIPTION
## Description
Whenever dependabot issued PRs, based on the logic I had in the CI GH workflow, it would add the `refactor` label. I didn't like this because it goes against my definition of `refactor`. I've updated the GH workflow to instead add the `enhancement` label.

## Approach Taken
Update the regex for the appropriate labels.

## What Could Go Wrong?
NA

## Remediation Strategy
NA
