### PR TITLE
XMDEV-493: Adds get available metrics route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ redis-stop:
 
 .PHONY: test
 test:
-	poetry run python -m pytest
+	poetry run python -m pytest $(if $(TEST),$(TEST),.)
 
 .PHONY: lint
 lint:

--- a/src/api/v1/metrics_sync.py
+++ b/src/api/v1/metrics_sync.py
@@ -16,6 +16,8 @@ from src.models.schemas import (
     MetricsResponse,
 )
 from src.api.auth.dependencies import verify_api_key
+from src.core.metrics.registry import metric_registry
+
 
 router = APIRouter()
 
@@ -31,12 +33,16 @@ async def get_available_metrics(
     by the API. It does not perform any metric calculations.
     """
     try:
-        available_metrics = ["bleu", "rouge", "meteor", "bertscore"]
+        available_metrics = metric_registry.list_available_metrics()
+
+        metric_info = [
+            metric_registry.get_metric_info(name) for name in available_metrics
+        ]
 
         return IndexResponse(
             success=True,
             message="Available metrics retrieved successfully.",
-            results=available_metrics,
+            results=metric_info,
         )
 
     except Exception as e:

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -117,4 +117,4 @@ class IndexResponse(BaseModel):
 
     success: bool
     message: str
-    results: List[str]
+    results: List[Dict[str, Any]]


### PR DESCRIPTION
## Description
When the application is running, there is no way for people to understand which metrics are currently discovered by the application.

## Approach Taken
Adds a new GET route that allows users to query the application to understand which metrics are currently available.

## What Could Go Wrong?
Nothing. This is solely a GET request route that returns information.

## Remediation Strategy
NA
