### PR TITLE
Configure env var

### DIFF
--- a/src/celery/celery_app.py
+++ b/src/celery/celery_app.py
@@ -11,7 +11,7 @@ import sys
 from celery import Celery, signals
 
 from src.core.settings import settings
-from .config import get_celery_config
+from .config import get_config_for_environment
 
 # Configure logging
 logging.basicConfig(
@@ -35,7 +35,7 @@ celery_app = Celery(
 )
 
 # Apply configuration
-celery_app.conf.update(get_celery_config())
+celery_app.conf.update(get_config_for_environment(settings.environment))
 
 
 @signals.setup_logging.connect

--- a/src/celery/config.py
+++ b/src/celery/config.py
@@ -5,7 +5,7 @@ This module contains all Celery-specific configuration in one place,
 making it easy to modify settings without touching the core app setup.
 """
 
-from typing import Dict, Any
+from typing import Dict, Any, Literal
 
 
 def get_celery_config() -> Dict[str, Any]:
@@ -71,3 +71,21 @@ def get_production_config() -> Dict[str, Any]:
         }
     )
     return config
+
+
+def get_config_for_environment(
+    environment: Literal["development", "production"],
+) -> Dict[str, Any]:
+    """
+    Get Celery configuration for the specified environment.
+
+    Args:
+        environment: The environment to get configuration for
+
+    Returns:
+        Dictionary containing environment-specific Celery configuration
+    """
+    if environment == "production":
+        return get_production_config()
+
+    return get_development_config()

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -1,6 +1,7 @@
 """Application settings loaded from environment variables."""
 
 from pathlib import Path
+from typing import Literal
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 
@@ -38,9 +39,9 @@ class Settings(BaseSettings):
     )
 
     # Environment
-    environment: str = Field(
+    environment: Literal["development", "production"] = Field(
         default="development",
-        description="Application environment (development, staging, production)",
+        description="Application environment (development or production)",
     )
 
     # Webhook settings

--- a/tests/celery/test_celery_app.py
+++ b/tests/celery/test_celery_app.py
@@ -78,16 +78,6 @@ class TestCeleryAppInitialization:
         # but we can verify the settings module is used
         assert mock_settings is not None
 
-    @patch("src.celery.celery_app.get_celery_config")
-    def test_celery_app_applies_configuration(self, mock_get_config):
-        """Test that Celery configuration is applied."""
-        mock_config = {"task_serializer": "json", "result_serializer": "json"}
-        mock_get_config.return_value = mock_config
-
-        # Since conf.update was already called during import,
-        # we verify the function would be called
-        assert mock_get_config is not None
-
 
 class TestSetupCeleryLogging:
     """Test the setup_celery_logging signal handler."""

--- a/tests/celery/test_config.py
+++ b/tests/celery/test_config.py
@@ -4,6 +4,7 @@ Tests for Celery configuration module.
 
 from src.celery.config import (
     get_celery_config,
+    get_config_for_environment,
     get_development_config,
     get_production_config,
 )
@@ -83,3 +84,54 @@ def test_get_production_config():
     }
 
     assert get_production_config() == expected
+
+
+def test_get_config_for_environment_for_production():
+    """Test that get_production_config returns expected configuration."""
+    expected = {
+        # Base config
+        "task_serializer": "json",
+        "accept_content": ["json"],
+        "result_serializer": "json",
+        "timezone": "UTC",
+        "enable_utc": True,
+        "result_expires": 3600,
+        "result_persistent": True,
+        "task_acks_late": True,
+        "task_reject_on_worker_lost": True,
+        "task_default_retry_delay": 60,
+        "task_max_retries": 3,
+        # Production overrides
+        "worker_prefetch_multiplier": 4,
+        "worker_max_tasks_per_child": 5000,
+        "task_soft_time_limit": 300,
+        "task_time_limit": 600,
+    }
+
+    assert get_config_for_environment("production") == expected
+
+
+def test_get_config_for_environment_for_development():
+    """Test that get_development_config returns expected configuration."""
+    expected = {
+        # Base config
+        "task_serializer": "json",
+        "accept_content": ["json"],
+        "result_serializer": "json",
+        "timezone": "UTC",
+        "enable_utc": True,
+        "result_expires": 3600,
+        "result_persistent": True,
+        "worker_prefetch_multiplier": 1,
+        "task_acks_late": True,
+        "worker_max_tasks_per_child": 1000,
+        "task_reject_on_worker_lost": True,
+        "task_default_retry_delay": 60,
+        "task_max_retries": 3,
+        # Development overrides
+        "task_always_eager": False,
+        "task_eager_propagates": True,
+        "worker_log_level": "DEBUG",
+    }
+
+    assert get_config_for_environment("development") == expected


### PR DESCRIPTION
## Description
We wanted to update the use of the environment env var in settings to dictate the configuration of celery.

## Approach Taken
Updated the setting to support either `production` or `development`, and added a new config method that takes in the setting as a param.

## What Could Go Wrong?
Nothing. Config wasn't previously used. This can be considered a bug fix.

## Remediation Strategy
NA
