### PR TITLE
XMDEV-488: Adds route to configure metrics through the API

### DIFF
--- a/src/core/metrics/base.py
+++ b/src/core/metrics/base.py
@@ -146,6 +146,12 @@ class BaseMetric(ABC):
             "description": self.description,
         }
 
+    def configure(self, config: Any = None) -> None:
+        """Implement the configuration per metric."""
+        raise NotImplementedError(
+            f"Metric {self.name} does not have a configuration method at this time."
+        )
+
     def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.name})"
 

--- a/src/core/metrics/implementations/bleu_score.py
+++ b/src/core/metrics/implementations/bleu_score.py
@@ -1,7 +1,7 @@
 """BLEU Score metric implementation."""
 
 from dataclasses import dataclass
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 import logging
 from src.core.metrics.base import BaseMetric
 from src.models.schemas import MetricType, MetricResult, TextPair
@@ -246,20 +246,25 @@ class BleuMetric(BaseMetric):
             "requires_download": False,
         }
 
-    def configure(self, config: Optional[BleuConfig] = None) -> None:
+    def configure(self, config: Optional[Union[BleuConfig, dict]] = None) -> None:
         """
         Update BLEU configuration. Will take effect on next computation.
         Allows you to update the settings at runtime without recreating the metric.
 
         Args:
-            max_n: Maximum n-gram order to consider
-            smooth_method: Smoothing method ('exp', 'floor', 'add-k', 'none')
-            smooth_value: Smoothing value for add-k method
-            tokenize: Tokenization method ('13a', 'intl', 'zh', 'ja-mecab', 'none')
-            lowercase: Whether to lowercase the input
+            config: BLEU configuration object or dictionary with configuration parameters
         """
         if config is None:
             return
+
+        # Handle dictionary input by converting to BleuConfig
+        if isinstance(config, dict):
+            try:
+                config = BleuConfig(**config)
+            except TypeError as e:
+                raise ValueError(f"Invalid BLEU configuration parameters: {e}") from e
+            except Exception as e:
+                raise ValueError(f"Failed to create BLEU configuration: {e}") from e
 
         if config.max_n is not None:
             self.config.max_n = config.max_n

--- a/src/core/metrics/implementations/bleu_score.py
+++ b/src/core/metrics/implementations/bleu_score.py
@@ -246,7 +246,7 @@ class BleuMetric(BaseMetric):
             "requires_download": False,
         }
 
-    def configure(self, config: Optional[BleuConfig] = None):
+    def configure(self, config: Optional[BleuConfig] = None) -> None:
         """
         Update BLEU configuration. Will take effect on next computation.
         Allows you to update the settings at runtime without recreating the metric.

--- a/src/core/metrics/implementations/rouge_score.py
+++ b/src/core/metrics/implementations/rouge_score.py
@@ -1,7 +1,7 @@
 """ROUGE Score metric implementation."""
 
 from dataclasses import dataclass, field
-from typing import List, Dict, Any, Set, Optional
+from typing import List, Dict, Any, Set, Optional, Union
 import logging
 from src.core.metrics.base import BaseMetric
 from src.models.schemas import MetricType, MetricResult, TextPair
@@ -260,16 +260,24 @@ class RougeMetric(BaseMetric):
             "supported_types": sorted(self.get_supported_rouge_types()),
         }
 
-    def configure(self, config: Optional[RougeConfig] = None) -> None:
+    def configure(self, config: Optional[Union[RougeConfig, dict]] = None) -> None:
         """
         Update ROUGE configuration. Will take effect on next computation.
         Forces reinitialization of the scorer with new settings.
 
         Args:
-            config: ROUGE configuration object
+            config: ROUGE configuration object or dictionary with configuration parameters
         """
         if config is None:
             return
+
+        if isinstance(config, dict):
+            try:
+                config = RougeConfig(**config)
+            except TypeError as e:
+                raise ValueError(f"Invalid ROUGE configuration parameters: {e}") from e
+            except Exception as e:
+                raise ValueError(f"Failed to create ROUGE configuration: {e}") from e
 
         config_changed = False
 

--- a/src/core/metrics/registry.py
+++ b/src/core/metrics/registry.py
@@ -192,6 +192,7 @@ class MetricRegistry:
             "description": metric.description,
             "requires_model_download": metric.requires_model_download,
             "class_name": metric.__class__.__name__,
+            **metric.get_model_info(),
         }
 
     def get_all_metrics_info(

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -118,3 +118,26 @@ class IndexResponse(BaseModel):
     success: bool
     message: str
     results: List[Dict[str, Any]]
+
+
+class MetricsConfigRequest(BaseModel):
+    """Request model for configuring metrics."""
+
+    configs: Dict[MetricType, Dict[str, Any]] = Field(
+        ...,
+        description="Dictionary mapping metric types to their specific configuration parameters",
+    )
+
+
+class MetricsConfigResponse(BaseModel):
+    """Response model for metrics configuration."""
+
+    success: bool
+    message: str
+    configured_metrics: Optional[List[str]] = Field(
+        default=None, description="List of successfully configured metrics"
+    )
+    failed_metrics: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary of metrics that failed to configure and their error messages",
+    )

--- a/tests/core/metrics/test_base.py
+++ b/tests/core/metrics/test_base.py
@@ -82,6 +82,13 @@ class TestBaseMetric:
             "description": "custom_name evaluation metric",
         }
 
+    def test_configure_not_implemented(self):
+        """Test that configure method raises NotImplementedError by default."""
+        metric = ConcreteMetric()
+        with pytest.raises(NotImplementedError) as exc_info:
+            metric.configure()
+        assert "does not have a configuration method" in str(exc_info.value)
+
     def test_compute_single_basic(self):
         """Test single computation works correctly."""
         metric = ConcreteMetric()


### PR DESCRIPTION
## Description
User feedback came in and folks wanted to be able to configure metrics on the fly. This PR adds that ability.

## Approach Taken
Adds a new route to enable users to configure metrics through the API.

## What Could Go Wrong?
Nothing. Greenfield code.

## Remediation Strategy
NA
