### PR TITLE
NO-JIRA: Fix issue with openapi version tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,6 @@ jobs:
       - name: Install dependencies
         run: poetry install --extras "all"
 
-      - name: Generate OpenAPI schema
-        run: poetry run python scripts/generate_openapi.py
-
       - name: Generate Changelog and Version
         run: |
           # Generate changelog
@@ -233,6 +230,9 @@ jobs:
           echo "$NEW_VERSION" > VERSION
           echo "Version bumped to: $NEW_VERSION"
 
+      - name: Generate OpenAPI schema
+        run: poetry run python scripts/generate_openapi.py
+      
       - name: Commit Changelog and Version Updates
         run: |
           TAG_NAME="v$(cat VERSION)"


### PR DESCRIPTION
## Description
I noticed there was an issue with the openapi json generation. The incorrect version was being selected.

## Approach Taken
Changed the order of operations within the create release workflow so that the openapi spec is generated after the version has been successfully incremented.

## What Could Go Wrong?
This is a bug fix so things have technically already got wrong!

## Remediation Strategy
NA
